### PR TITLE
Fix: IPFS 파일 업로드 시 확장자 보존을 위해 wrap_with_directory 옵션 적용

### DIFF
--- a/ipfs/upload.py
+++ b/ipfs/upload.py
@@ -18,7 +18,7 @@ class IPFSUploader:
     """IPFS에 실제 파일을 업로드하고 DHT 등록 및 핀 처리를 수행하는 클래스"""
 
     def __init__(self, ipfs_api=None):
-        """IPFS 클라이언트 초기화 (실제 노드 연결)"""
+        """IPFS 클라이언트 초기화"""
         if ipfs_api is None:
             ipfs_api = os.getenv("IPFS_API_URL", "/ip4/127.0.0.1/tcp/5001")
         try:
@@ -30,7 +30,11 @@ class IPFSUploader:
             self.ipfs_available = False
 
     def upload_file(self, file_path):
-        """파일을 IPFS에 업로드하고 DHT 등록 및 핀(Pin) 처리"""
+        """
+        파일을 IPFS에 업로드하고 DHT 등록 및 핀(Pin) 처리
+        :param file_path: 업로드할 로컬 파일 경로
+        :return: {cid, file_name, sha3}
+        """
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"⚠️ 파일을 찾을 수 없습니다: {file_path}")
 
@@ -38,32 +42,47 @@ class IPFSUploader:
             if self.ipfs_available:
                 logger.info(f"⏳ IPFS에 파일 업로드 시작: {file_path}")
 
-                # 🔹 파일을 읽고 SHA-3 해시 계산
+                # SHA-3 해시 계산
                 with open(file_path, "rb") as f:
                     file_data = f.read()
-
                 sha3_hash = hashlib.sha3_256(file_data).hexdigest()
                 logger.info(f"🔑 SHA-3 해시 계산 완료: {sha3_hash}")
 
-                # 🔹 IPFS에 파일 업로드
-                result = self.client.add(file_path)
-                cid = result["Hash"]
-                logger.info(f"✅ 파일 업로드 완료! CID: {cid}")
+                # wrap-with-directory 옵션 → 파일명 보존
+                result = self.client.add(file_path, wrap_with_directory=True)
 
-                # 🔹 DHT 등록 (CLI 실행)
+                """
+                result는 배열 형태로 반환됨 (디렉토리와 파일 CID 모두 포함)
+                [
+                    {'Name': '파일명.py.enc', 'Hash': 'QmFileCID', 'Size': '1234'},
+                    {'Name': '', 'Hash': 'QmDirCID', 'Size': '2345'}
+                ]
+                """
+                # 디렉토리 CID (블록체인에 저장할 값)
+                dir_entry = next(r for r in result if r["Name"] == "")
+                dir_cid = dir_entry["Hash"]
+
+                # 파일명은 따로 기록용
+                file_entry = next(r for r in result if r["Name"] != "")
+                file_name = file_entry["Name"]
+
+                # 블록체인에 저장할 해시값은 디렉토리 CID
+                cid = dir_cid
+
+                logger.info(f"✅ 파일 업로드 완료! CID: {cid}, 파일명: {file_name}")
+
+                # DHT 등록
                 logger.info("📢 DHT에 CID 등록 중...")
-                subprocess.run(
-                    ["ipfs", "dht", "provide", cid], capture_output=True, text=True
-                )
-                time.sleep(5)  # DHT 등록이 퍼질 시간을 줌
+                subprocess.run(["ipfs", "dht", "provide", cid], capture_output=True, text=True)
+                time.sleep(5)
                 logger.info("✅ DHT 등록 완료!")
 
-                # 🔹 핀 추가 (파일을 노드에 유지)
+                # 핀 추가
                 logger.info("📌 핀 설정 중...")
                 self.client.pin.add(cid)
                 logger.info("✅ 핀 설정 완료!")
 
-                return cid  # CID 반환
+                return {"cid": cid, "file_name": file_name, "sha3": sha3_hash}
 
             else:
                 raise ConnectionError("🚨 IPFS 노드에 연결할 수 없습니다.")

--- a/services/update_service.py
+++ b/services/update_service.py
@@ -71,11 +71,19 @@ class UpdateService:
         # IPFS에 암호화된 바이너리 업로드
         try:
             ipfs_uploader = IPFSUploader()
-            ipfs_hash = ipfs_uploader.upload_file(encrypted_file_path)
-            logger.info(f"IPFS 업로드 완료: {ipfs_hash}")
+            upload_result = ipfs_uploader.upload_file(encrypted_file_path)
+            if not upload_result:
+                raise Exception("IPFS 업로드 결과가 없습니다.")
+
+            ipfs_hash = upload_result["cid"]
+            file_name = upload_result["file_name"]
+            sha3_hash = upload_result["sha3"]
+
+            logger.info(f"IPFS 업로드 완료: CID={ipfs_hash}, 파일명={file_name}, SHA3={sha3_hash}")
+
         except ConnectionError as ce:
             logger.error(f"IPFS 연결 오류: {ce}")
-            return jsonify({"error": f"IPFS 연결에 실패했습니다.: {e}"}), 500
+            return jsonify({"error": f"IPFS 연결에 실패했습니다: {ce}"}), 500
         except Exception as e:
             logger.error(f"IPFS 업로드 중 예외 발생: {e}")
             return jsonify({"error": f"IPFS 업로드 실패: {e}"}), 500


### PR DESCRIPTION
## 변경 사항
- 파일 업로드 시 `wrap_with_directory=True` 옵션을 적용하여 IPFS 내부에 디렉토리 구조를 생성하고, 그 안에 실제 파일을 포함하도록 변경
- 원본 파일명(xxx.py.enc)을 유지할 수 있으며, 다운로드 시 확장자 복원 가능

기존의 DHT 등록 및 Pinning 로직은 그대로 유지됨