### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/services/update_service.py
+++ b/services/update_service.py
@@ -73,7 +73,7 @@ class UpdateService:
             logger.info(f"IPFS 업로드 완료: CID={ipfs_hash}, 파일명={file_name}")
         except Exception as e:
             logger.error(f"IPFS 업로드 실패: {e}")
-            return jsonify({"error": f"IPFS 업로드 실패: {e}"}), 500
+            return jsonify({"error": "IPFS 업로드에 실패했습니다. 관리자에게 문의하세요."}), 500
 
         # CP-ABE 키 생성
         key_dir = os.path.join(os.path.dirname(__file__), "../crypto/keys")


### PR DESCRIPTION
Potential fix for [https://github.com/HSU-Blocker/Blocker_Manufacturer_Backend/security/code-scanning/2](https://github.com/HSU-Blocker/Blocker_Manufacturer_Backend/security/code-scanning/2)

The best way to fix this problem is to avoid sending the raw exception message back to the client. Instead, provide a generic error message, and log full exception details server-side for debugging purposes.  

Specifically:  
- On line 76, replace `jsonify({"error": f"IPFS 업로드 실패: {e}"})` with a generic user-facing message, e.g., `"IPFS 업로드에 실패했습니다. 관리자에게 문의하세요."`
- Ensure the detailed exception info (ideally including stack trace) is logged only on the server, which is already done by `logger.error()` on line 75.
- No new methods are needed, though optionally, you could expand logging with `logger.exception(e)` to also capture the stack trace (if desired).
- No new imports are required unless you want to use `traceback` in logging, which isn't strictly necessary in this case.

You only need to edit the relevant return statement (line 76) in file `services/update_service.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
