### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/services/update_service.py
+++ b/services/update_service.py
@@ -155,9 +155,9 @@ class UpdateService:
                 "signature": base64.b64encode(signature).decode(),
             }
         except Exception as e:
-            # [추가] 리버트/가스/잔액 등 상세 사유를 그대로 전달
+            # [보안] 상세 사유는 서버 로그에만 남기고 클라이언트에는 일반 메시지 전송
             logger.exception("블록체인 등록 실패")
-            return jsonify({"error": f"Blockchain register_update failed: {str(e)}"}), 500
+            return jsonify({"error": "Blockchain register_update failed"}), 500
 
     @staticmethod
     def build_attribute_policy(policy_dict):


### PR DESCRIPTION
Potential fix for [https://github.com/HSU-Blocker/Blocker_Manufacturer_Backend/security/code-scanning/3](https://github.com/HSU-Blocker/Blocker_Manufacturer_Backend/security/code-scanning/3)

To fix the issue, the exception block at line 157 should return a more generic error message to the client, avoiding exposure of `str(e)` (the exception message). The stack trace and details should continue to be logged on the server via `logger.exception`, but the API response should only relay a generic error such as `"Blockchain register_update failed"`, or even just `"An internal error occurred"`. This maintains functionality (logging for debugging) but prevents leaking stack traces or sensitive messages to API users. The change is fully confined to the exception handler in this file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
